### PR TITLE
Sqs logging

### DIFF
--- a/atompub.go
+++ b/atompub.go
@@ -34,7 +34,7 @@ func NewAtomDataProcessor(db *sql.DB) *AtomDataProcessor {
 }
 
 func (adp *AtomDataProcessor) ProcessMessage(msg string) error {
-	log.Debugf("process message %s", msg)
+	log.Infof("process message %s", msg)
 
 	var aggId, typecode string
 	var version int
@@ -54,7 +54,7 @@ func (adp *AtomDataProcessor) ProcessMessage(msg string) error {
 		TypeCode: typecode,
 	}
 
-	return adp.processEvent(&event,timestamp)
+	return adp.processEvent(&event, timestamp)
 }
 
 func selectLatestFeed(tx *sql.Tx) (sql.NullString, error) {
@@ -91,7 +91,7 @@ func doRollback(tx *sql.Tx) {
 func writeEventToAtomEventTable(tx *sql.Tx, event *goes.Event, ts time.Time) error {
 	log.Debug("insert event into atom_event")
 	_, err := tx.Exec(sqlInsertEventIntoFeed,
-		event.Source, event.Version, event.TypeCode, event.Payload,ts)
+		event.Source, event.Version, event.TypeCode, event.Payload, ts)
 	return err
 }
 

--- a/atompub_test.go
+++ b/atompub_test.go
@@ -109,7 +109,7 @@ func testEventInsertSetup(mock sqlmock.Sqlmock, ok *bool, eventPtr *goes.Event) 
 	if *ok == true {
 		execOkResult := sqlmock.NewResult(1, 1)
 		mock.ExpectExec("insert into t_aeae_atom_event").WithArgs(
-			eventPtr.Source, eventPtr.Version, eventPtr.TypeCode, eventPtr.Payload,ts,
+			eventPtr.Source, eventPtr.Version, eventPtr.TypeCode, eventPtr.Payload, ts,
 		).WillReturnResult(execOkResult)
 	} else {
 		mock.ExpectExec("insert into t_aeae_atom_event").WillReturnError(errors.New("BAM!"))
@@ -221,7 +221,7 @@ func TestProcessEvents(t *testing.T) {
 
 		assert.Nil(t, err)
 
-		eventMessage := pgpublish.EncodePGEvent(eventPtr.Source, eventPtr.Version, (eventPtr.Payload).([]byte), eventPtr.TypeCode,ts)
+		eventMessage := pgpublish.EncodePGEvent(eventPtr.Source, eventPtr.Version, (eventPtr.Payload).([]byte), eventPtr.TypeCode, ts)
 
 		err = processor.ProcessMessage(eventMessage)
 		if tt.expectError {

--- a/cmd/eventprocessor.go
+++ b/cmd/eventprocessor.go
@@ -143,7 +143,7 @@ func main() {
 
 		message := *messages[0]
 
-		loggingFields := log.Fields{"msg id": *message.MessageId}
+		loggingFields := log.Fields{"MsgId": *message.MessageId}
 
 		log.WithFields(loggingFields).Infof("Extracting SNS message from %s", *message.MessageId)
 

--- a/cmd/eventprocessor.go
+++ b/cmd/eventprocessor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/xtracdev/pgconn"
 	"github.com/xtracdev/pgpublish"
 	"os"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -52,7 +53,12 @@ func init() {
 
 func warnErrorf(format string, args ...interface{}) {
 	metricsSink.IncrCounter(errorCounter, 1)
-	log.Warnf(format, args)
+	log.Warnf(format, args...)
+}
+
+func warnErrorfWithFields(fields log.Fields, format string, args ...interface{}) {
+	metricsSink.IncrCounter(errorCounter, 1)
+	log.WithFields(fields).Warnf(format, args...)
 }
 
 func errorDelay() {
@@ -69,7 +75,20 @@ func SNSMessageFromRawMessage(raw string) (*SNSMessage, error) {
 	return &snsMessage, err
 }
 
+func retryMessage(err error) bool {
+
+	errorMsg := err.Error()
+	if strings.Contains(errorMsg, "duplicate key value violates unique constraint") {
+		return false
+	}
+
+	return true
+}
+
 func main() {
+
+	log.SetFormatter(&log.JSONFormatter{})
+
 	pgpublish.SetLogLevel(LogLevel)
 	esatomdatapg.ReadFeedThresholdFromEnv()
 
@@ -123,27 +142,45 @@ func main() {
 		metricsSink.IncrCounter(messagesReceived, 1)
 
 		message := *messages[0]
-		log.Debugf("Message: %v", message)
 
+		loggingFields := log.Fields{"msg id": *message.MessageId}
+
+		log.WithFields(loggingFields).Infof("Extracting SNS message from %s", *message.MessageId)
+
+		snsMessageOK := true
 		sns, err := SNSMessageFromRawMessage(*message.Body)
 		if err != nil {
-			warnErrorf(err.Error())
-			errorDelay()
-			continue
+			snsMessageOK = false
+			warnErrorfWithFields(log.Fields{"msg id": *message.MessageId}, err.Error())
 		}
 
-		start := time.Now()
-		err = atomDataProcessor.ProcessMessage(sns.Message)
-		if err != nil {
-			warnErrorf("Error processing message: %s", err.Error())
-			continue
+		if snsMessageOK {
+			log.WithFields(loggingFields).Infof("Processing message from %s", *message.MessageId)
+
+			start := time.Now()
+			err = atomDataProcessor.ProcessMessage(sns.Message)
+			if err != nil {
+				warnErrorfWithFields(
+					loggingFields,
+					"Error processing message: %s",
+					err.Error(),
+				)
+
+				if retryMessage(err) == true {
+					continue
+				}
+			} else {
+
+				log.WithFields(loggingFields).Info("Sucessfully processed message ")
+
+			}
+			stop := time.Now()
+
+			metricsSink.IncrCounter(messagesProcessed, 1)
+			metrics.AddSample(processingTime, float32(stop.Sub(start).Nanoseconds()/1000000.0))
 		}
-		stop := time.Now()
 
-		metricsSink.IncrCounter(messagesProcessed, 1)
-		metrics.AddSample(processingTime, float32(stop.Sub(start).Nanoseconds()/1000000.0))
-
-		log.Debug("Delete message")
+		log.WithFields(loggingFields).Infof("Delete message %s", *message.MessageId)
 
 		params := &sqs.DeleteMessageInput{
 			QueueUrl:      aws.String(queueURL),

--- a/db/migration/V201704250931__atom_feed.sql
+++ b/db/migration/V201704250931__atom_feed.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS t_aeae_atom_event(
     version NUMERIC(38,0) NOT NULL,
     typecode CHARACTER VARYING(30) NOT NULL,
     payload BYTEA,
-    primary key(id)
+    primary key(aggregate_id,version)
 )
 WITH (
     OIDS=FALSE

--- a/internal/features/atom/feedassigned_steps.go
+++ b/internal/features/atom/feedassigned_steps.go
@@ -56,7 +56,7 @@ func init() {
 			Payload:  []byte("ok"),
 		}
 
-		encodedEvent := pgpublish.EncodePGEvent(eventPtr.Source, eventPtr.Version, (eventPtr.Payload).([]byte), eventPtr.TypeCode,ts)
+		encodedEvent := pgpublish.EncodePGEvent(eventPtr.Source, eventPtr.Version, (eventPtr.Payload).([]byte), eventPtr.TypeCode, ts)
 		err = atomProcessor.ProcessMessage(encodedEvent)
 		assert.Nil(T, err)
 

--- a/internal/features/atom/feedinit_steps.go
+++ b/internal/features/atom/feedinit_steps.go
@@ -57,7 +57,7 @@ func init() {
 			TypeCode: "foo",
 			Payload:  []byte("ok"),
 		}
-		encodedEvent := pgpublish.EncodePGEvent(eventPtr.Source, eventPtr.Version, (eventPtr.Payload).([]byte), eventPtr.TypeCode,ts)
+		encodedEvent := pgpublish.EncodePGEvent(eventPtr.Source, eventPtr.Version, (eventPtr.Payload).([]byte), eventPtr.TypeCode, ts)
 		err = atomProcessor.ProcessMessage(encodedEvent)
 		assert.Nil(T, err)
 	})


### PR DESCRIPTION
Updated SQS logging to provide more context for troubleshooting, and updated the code to not bother retrying two operations that can never succeed (receipt of malformed message, and duplicate key constraint violation).